### PR TITLE
Add .gitattributes to help merges go more smoothly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.min.js binary
+*.map binary
+


### PR DESCRIPTION
This flags all *.min.js and *.map files as binary files, meaning that Git won't try to use deltas to merge them - it will treat them as one big blob (which they are, since they're one-line files).